### PR TITLE
Fix the shorter method call for BRKGA_MP_IPR::pathRelinking

### DIFF
--- a/brkga_mp_ipr/brkga_mp_ipr.hpp
+++ b/brkga_mp_ipr/brkga_mp_ipr.hpp
@@ -2357,8 +2357,9 @@ PathRelinking::PathRelinkingResult BRKGA_MP_IPR<Decoder>::pathRelink(
     if(block_size > CHROMOSOME_SIZE)
         block_size = CHROMOSOME_SIZE / 2;
 
-    return pathRelink(dist, params.pr_number_pairs, params.pr_minimum_distance,
-                      params.pr_type, params.pr_selection, block_size, max_time,
+    return pathRelink(params.pr_type, params.pr_selection, dist, 
+                      params.pr_number_pairs, params.pr_minimum_distance,
+                      block_size, max_time,
                       params.pr_percentage);
 }
 


### PR DESCRIPTION
Hi @ceandrade, I was testing your library and I think I found a typo in the "shortcut" method for IPR. This problem only came up now due to how the C++ compiler handles template specializations. 

Feel free to deny this pull request if I misunderstood the problem!
Best,
Alberto Kummer