### PR TITLE
In directPathRelink, if remaining_blocks becames empty, it ends

### DIFF
--- a/brkga_mp_ipr/brkga_mp_ipr.hpp
+++ b/brkga_mp_ipr/brkga_mp_ipr.hpp
@@ -2756,6 +2756,10 @@ void BRKGA_MP_IPR<Decoder>::directPathRelink(
             ++it_block_idx;
         }
 
+        if (remaining_blocks.empty()) {
+            break;
+        }
+
         // Decode the candidates.
         volatile bool times_up = false;
         #ifdef _OPENMP


### PR DESCRIPTION
After for in line [2730](https://github.com/ceandrade/brkga_mp_ipr_cpp/blob/d17a75b3b324331d9ac529abd58bfc4eca8810c7/brkga_mp_ipr/brkga_mp_ipr.hpp#L2730), an if checks if ``remaining_blocks`` is empty, in this case it breaks the while.